### PR TITLE
Add require: false to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this line to your application's Gemfile:
 ```ruby
 group :development do
   gem 'capistrano', '~> 3.7'
-  gem 'capistrano-hanami'
+  gem 'capistrano-hanami', require: false
 end
 ```
 


### PR DESCRIPTION
I think it's needed, otherwise it results to `uninitialized constant Capistrano` error during `hanami server -p 3000` in development environment.

Adding `require: false` solves this problem.